### PR TITLE
:sparkle: SQLFrame and Duckdb

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         # Install a specific version of uv.
-        version: 0.7.13
+        version: 0.9.8
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         # Install a specific version of uv.
         version: 0.7.13

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,12 +11,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           # Install a specific version of uv.
-          version: "0.7.13"
+          version: 0.9.8
       - name: Build & publish package
         run: |
           uv build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.27.2  # Specify the desired version of Gitleaks
+    rev: v8.29.0  # Specify the desired version of Gitleaks
     hooks:
       - id: gitleaks
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.14.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -16,6 +16,6 @@ repos:
       args: ["-c", "pyproject.toml"]
       additional_dependencies: ["bandit[toml]"]
   - repo: https://github.com/facebook/pyrefly
-    rev: 0.22.2
+    rev: 0.40.1
     hooks:
       - id: pyrefly-typecheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.4
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
       - id: ruff-format
   - repo: https://github.com/PyCQA/bandit

--- a/README.md
+++ b/README.md
@@ -53,8 +53,19 @@ This pytest plugin aims to create a useful baseline for spark unit testing. Ther
 
 ## :tada: Feature Description :sparkles:
 
-### SparkSession Fixture
-A Spark Session, optimized for standalone or 0-Worker Cluster is provided with minimal shuffling and other configurations.
+### SparkSession Fixture with underlying engine
+One way of doing things simply isn't enough. Especially when testing targeted for data wrangling code. Sometimes you just want to assure that the logic is correct, then the test needs to be blazing fast even on small datasets. This is where Spark **doesn't** shine ... but **DuckDB** does. Then sometimes you want to test your code against real world data. This is difficult if your data is located in the cloud. With spark-connect, this is way easier, e.g. running your tests as a client sending the job to a Databricks cluster. Therefore the overall goal is to easily switch between those scenarios.
+
+Currently supported:
+- Standalone local SparkSession as a default option
+- SparkConnect session defined via `--spark-remote-url`
+- SQLFrame DuckDBSession triggered via `--engine=duckdb` cli argument
+
+**Order of precedence**
+1. The `--engine` argument differentiates between `spark` (*default*) and `duckdb` and therefore is of the highest order. All other arguments will be ignored.
+2. The `--spark-remote-url` argument 
+3. Fallback is a default, standalone spark session.
+> __NOTE__: Depending on your session, further dependencies may need to be installed (e.g. java)
 
 ### Markers
 The plugin adds a new marker to pytest, `@pytest.mark.spark` which marks the test to require a running spark session.

--- a/p3/_internals.py
+++ b/p3/_internals.py
@@ -99,3 +99,13 @@ class Generator:
     @staticmethod
     def create_dataframe(schema: StructType) -> DataFrame:
         raise NotImplementedError('Synthetic Data Generation is currently not supported')
+
+
+class SessionGenerator:
+    def __init__(self, engine: str):
+        if engine == 'duckdb':
+            logger.info('Creating duckdb session.')
+        elif engine == 'remote':
+            logger.info('Creating remote spark session.')
+        else:
+            logger.info('Creating regular spark session.')

--- a/p3/plugin.py
+++ b/p3/plugin.py
@@ -2,7 +2,7 @@ import logging
 from contextlib import contextmanager
 import _pytest  # noqa
 import pytest
-from pyspark.sql import SparkSession
+from p3._internals import SessionGenerator
 
 logger = logging.getLogger('p3')
 
@@ -10,8 +10,9 @@ logger = logging.getLogger('p3')
 @pytest.fixture(scope='session')
 def spark(request):
     """Yield SparkSession for testing session scope."""
-    logger.info('Creating SparkSession...')
-    spark = SparkSession.builder.master('local[*]').appName('spark_testing').getOrCreate()  # type: ignore
+    engine = request.config.getoption('--engine')
+    logger.info('Creating SparkSession with engine')
+    spark = SessionGenerator(engine).generate_session(request)
 
     logger.info('Set logLevel of py4j logger to ERROR')
     logging.getLogger('py4j').setLevel(logging.ERROR)
@@ -73,7 +74,6 @@ def pytest_addoption(parser: pytest.Parser):
 
     # ini options
     parser.addini('spark_conf', help='Options to be used in SparkSession', type='linelist')
-    parser.addini('spark_remote_url', help='Remote URL for spark-connect')
 
 
 def pytest_configure(config):

--- a/p3/plugin.py
+++ b/p3/plugin.py
@@ -8,7 +8,7 @@ logger = logging.getLogger('p3')
 
 
 @pytest.fixture(scope='session')
-def spark():
+def spark(request):
     """Yield SparkSession for testing session scope."""
     logger.info('Creating SparkSession...')
     spark = SparkSession.builder.master('local[*]').appName('spark_testing').getOrCreate()  # type: ignore
@@ -54,16 +54,26 @@ class SparkItem(pytest.Item):
 
 
 # Introduce custom option for spark plugin
-def pytest_addoption(parser):
-    # spark remote url
-    logger.info('The spark_remote_url and spark_conf options are without effect by now.')
-    parser.addini('spark_remote_url', help='Remote URL for spark-connect')
-    parser.addoption(
+def pytest_addoption(parser: pytest.Parser):
+    # spark configuration group
+    logger.warning('The spark_remote_url and spark_conf options are without effect by now.')
+    spark_test_opts = parser.getgroup('spark', description='spark testing config')
+    spark_test_opts.addoption(
         '--spark-remote-url',
         dest='spark_remote_url',
         help='Remote URL for spark-connect',
     )
+    spark_test_opts.addoption(
+        '--engine',
+        action='store',
+        dest='spark_testing_engine',
+        default='spark',
+        help='Engine for spark tests',
+    )
+
+    # ini options
     parser.addini('spark_conf', help='Options to be used in SparkSession', type='linelist')
+    parser.addini('spark_remote_url', help='Remote URL for spark-connect')
 
 
 def pytest_configure(config):

--- a/p3/plugin.py
+++ b/p3/plugin.py
@@ -68,7 +68,7 @@ def pytest_addoption(parser: pytest.Parser):
         '--engine',
         action='store',
         dest='spark_testing_engine',
-        default='spark',
+        default='local',
         help='Engine for spark tests',
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.11"
 dependencies = [
     "pyspark[connect]>=3.5.1",
     "pytest>=8.0.0",
-    "setuptools>=75.8.0",
     "sqlframe[duckdb]>=3.43.8",
 ]
 name = "pytest-pyspark-plugin"
@@ -27,10 +26,6 @@ classifiers = [
 
 [project.entry-points.pytest11]
 p3 = "plugin"
-
-[tool.uv]
-dev-dependencies = [
-]
 
 [tool.hatch.build.targets.wheel]
 only-include = ["p3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,10 @@ dependencies = [
     "pyspark[connect]>=3.5.1",
     "pytest>=8.0.0",
     "setuptools>=75.8.0",
+    "sqlframe[duckdb]>=3.43.8",
 ]
 name = "pytest-pyspark-plugin"
-version = "0.2.0"
+version = "0.3.0"
 description = "Pytest pyspark plugin (p3)"
 readme = "README.md"
 classifiers = [
@@ -20,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
 ]
 
 [project.entry-points.pytest11]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "pytest>=8.0.0",
     "sqlframe[duckdb]>=3.43.8",
 ]
-name = "pytest-pyspark-plugin"
+name = "p3"
 version = "0.3.0"
 description = "Pytest pyspark plugin (p3)"
 readme = "README.md"
@@ -25,11 +25,7 @@ classifiers = [
 ]
 
 [project.entry-points.pytest11]
-p3 = "plugin"
-
-[tool.hatch.build.targets.wheel]
-only-include = ["p3"]
-sources = ["p3"]
+p3 = "p3.plugin"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/_internals/test_spark_session.py
+++ b/tests/_internals/test_spark_session.py
@@ -1,0 +1,19 @@
+import pytest
+from p3._internals import SessionEngine, SessionGenerator
+
+
+def test_enumeration() -> None:
+    with pytest.raises(ValueError):
+        SessionGenerator(engine='arbitrary')
+
+
+@pytest.mark.parametrize(
+    ['key', 'value'],
+    [
+        ('DUCKDB', 1),
+        ('REMOTE', 2),
+        ('LOCAL', 3),
+    ],
+)
+def test_enum(key, value) -> None:
+    assert getattr(SessionEngine, key).value == value

--- a/tests/plugin/test_addoption.py
+++ b/tests/plugin/test_addoption.py
@@ -71,3 +71,16 @@ def test_no_spark_marker(pytester: Pytester):
     # check that all 4 tests passed
     # Still problem with
     result.assert_outcomes(deselected=1)
+
+
+def test_help_message(pytester):
+    result = pytester.runpytest(
+        '--help',
+    )
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(
+        [
+            '*--spark-remote-url=SPARK_REMOTE_URL',
+            '*--engine=SPARK_TESTING_ENGINE',
+        ]
+    )

--- a/tests/plugin/test_addoption.py
+++ b/tests/plugin/test_addoption.py
@@ -25,7 +25,7 @@ def test_active_plugin(pytester: Pytester):
     pytester.makepyfile(COLLECTION_FILE)
     res = pytester.runpytest()
     plugins_line = [s for s in res.outlines if s.startswith('plugins:')][0]
-    assert 'pyspark-plugin' in plugins_line
+    assert 'p3' in plugins_line
 
 
 def test_available_fixtures(pytester: Pytester):

--- a/uv.lock
+++ b/uv.lock
@@ -205,6 +205,23 @@ wheels = [
 ]
 
 [[package]]
+name = "p3"
+version = "0.3.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyspark", extra = ["connect"] },
+    { name = "pytest" },
+    { name = "sqlframe", extra = ["duckdb"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyspark", extras = ["connect"], specifier = ">=3.5.1" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "sqlframe", extras = ["duckdb"], specifier = ">=3.43.8" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -376,23 +393,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
-]
-
-[[package]]
-name = "pytest-pyspark-plugin"
-version = "0.3.0"
-source = { editable = "." }
-dependencies = [
-    { name = "pyspark", extra = ["connect"] },
-    { name = "pytest" },
-    { name = "sqlframe", extra = ["duckdb"] },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pyspark", extras = ["connect"], specifier = ">=3.5.1" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "sqlframe", extras = ["duckdb"], specifier = ">=3.43.8" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,32 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/e7/21cf50a3d52ffceee1f0bcc3997fa96a5062e6bab705baee4f6c4e33cce5/duckdb-1.4.1.tar.gz", hash = "sha256:f903882f045d057ebccad12ac69975952832edfe133697694854bb784b8d6c76", size = 18461687, upload-time = "2025-10-07T10:37:28.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/52/606f13fa9669a24166d2fe523e28982d8ef9039874b4de774255c7806d1f/duckdb-1.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:605d563c1d5203ca992497cd33fb386ac3d533deca970f9dcf539f62a34e22a9", size = 29065894, upload-time = "2025-10-07T10:36:29.837Z" },
+    { url = "https://files.pythonhosted.org/packages/84/57/138241952ece868b9577e607858466315bed1739e1fbb47205df4dfdfd88/duckdb-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d3305c7c4b70336171de7adfdb50431f23671c000f11839b580c4201d9ce6ef5", size = 16163720, upload-time = "2025-10-07T10:36:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/81/afa3a0a78498a6f4acfea75c48a70c5082032d9ac87822713d7c2d164af1/duckdb-1.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a063d6febbe34b32f1ad2e68822db4d0e4b1102036f49aaeeb22b844427a75df", size = 13756223, upload-time = "2025-10-07T10:36:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/47/dd/5f6064fbd9248e37a3e806a244f81e0390ab8f989d231b584fb954f257fc/duckdb-1.4.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1ffcaaf74f7d1df3684b54685cbf8d3ce732781c541def8e1ced304859733ae", size = 18487022, upload-time = "2025-10-07T10:36:36.759Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/10/b54969a1c42fd9344ad39228d671faceb8aa9f144b67cd9531a63551757f/duckdb-1.4.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685d3d1599dc08160e0fa0cf09e93ac4ff8b8ed399cb69f8b5391cd46b5b207c", size = 20491004, upload-time = "2025-10-07T10:36:39.318Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d5/7332ae8f804869a4e895937821b776199a283f8d9fc775fd3ae5a0558099/duckdb-1.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:78f1d28a15ae73bd449c43f80233732adffa49be1840a32de8f1a6bb5b286764", size = 12327619, upload-time = "2025-10-07T10:36:41.509Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/6c/906a3fe41cd247b5638866fc1245226b528de196588802d4df4df1e6e819/duckdb-1.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cd1765a7d180b7482874586859fc23bc9969d7d6c96ced83b245e6c6f49cde7f", size = 29076820, upload-time = "2025-10-07T10:36:43.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c7/01dd33083f01f618c2a29f6dd068baf16945b8cbdb132929d3766610bbbb/duckdb-1.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8ed7a86725185470953410823762956606693c0813bb64e09c7d44dbd9253a64", size = 16167558, upload-time = "2025-10-07T10:36:46.003Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e2/f983b4b7ae1dfbdd2792dd31dee9a0d35f88554452cbfc6c9d65e22fdfa9/duckdb-1.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8a189bdfc64cfb9cc1adfbe4f2dcfde0a4992ec08505ad8ce33c886e4813f0bf", size = 13762226, upload-time = "2025-10-07T10:36:48.55Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/34/fb69a7be19b90f573b3cc890961be7b11870b77514769655657514f10a98/duckdb-1.4.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9090089b6486f7319c92acdeed8acda022d4374032d78a465956f50fc52fabf", size = 18500901, upload-time = "2025-10-07T10:36:52.445Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/1395d7b49d5589e85da9a9d7ffd8b50364c9d159c2807bef72d547f0ad1e/duckdb-1.4.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:142552ea3e768048e0e8c832077a545ca07792631c59edaee925e3e67401c2a0", size = 20514177, upload-time = "2025-10-07T10:36:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/21/08f10706d30252753349ec545833fc0cea67c11abd0b5223acf2827f1056/duckdb-1.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:567f3b3a785a9e8650612461893c49ca799661d2345a6024dda48324ece89ded", size = 12336422, upload-time = "2025-10-07T10:36:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/08/705988c33e38665c969f7876b3ca4328be578554aa7e3dc0f34158da3e64/duckdb-1.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:46496a2518752ae0c6c5d75d4cdecf56ea23dd098746391176dd8e42cf157791", size = 29077070, upload-time = "2025-10-07T10:36:59.83Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c5/7c9165f1e6b9069441bcda4da1e19382d4a2357783d37ff9ae238c5c41ac/duckdb-1.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1c65ae7e9b541cea07d8075343bcfebdecc29a3c0481aa6078ee63d51951cfcd", size = 16167506, upload-time = "2025-10-07T10:37:02.24Z" },
+    { url = "https://files.pythonhosted.org/packages/38/46/267f4a570a0ee3ae6871ddc03435f9942884284e22a7ba9b7cb252ee69b6/duckdb-1.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:598d1a314e34b65d9399ddd066ccce1eeab6a60a2ef5885a84ce5ed62dbaf729", size = 13762330, upload-time = "2025-10-07T10:37:04.581Z" },
+    { url = "https://files.pythonhosted.org/packages/15/7b/c4f272a40c36d82df20937d93a1780eb39ab0107fe42b62cba889151eab9/duckdb-1.4.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2f16b8def782d484a9f035fc422bb6f06941ed0054b4511ddcdc514a7fb6a75", size = 18504687, upload-time = "2025-10-07T10:37:06.991Z" },
+    { url = "https://files.pythonhosted.org/packages/17/fc/9b958751f0116d7b0406406b07fa6f5a10c22d699be27826d0b896f9bf51/duckdb-1.4.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5a7d0aed068a5c33622a8848857947cab5cfb3f2a315b1251849bac2c74c492", size = 20513823, upload-time = "2025-10-07T10:37:09.349Z" },
+    { url = "https://files.pythonhosted.org/packages/30/79/4f544d73fcc0513b71296cb3ebb28a227d22e80dec27204977039b9fa875/duckdb-1.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:280fd663dacdd12bb3c3bf41f3e5b2e5b95e00b88120afabb8b8befa5f335c6f", size = 12336460, upload-time = "2025-10-07T10:37:12.154Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
@@ -86,6 +112,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]
@@ -229,6 +264,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prettytable"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b1/85e18ac92afd08c533603e3393977b6bc1443043115a47bb094f3b98f94f/prettytable-3.16.0.tar.gz", hash = "sha256:3c64b31719d961bf69c9a7e03d0c1e477320906a98da63952bc6698d6164ff57", size = 66276, upload-time = "2025-03-24T19:39:04.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c7/5613524e606ea1688b3bdbf48aa64bafb6d0a4ac3750274c43b6158a390f/prettytable-3.16.0-py3-none-any.whl", hash = "sha256:b5eccfabb82222f5aa46b798ff02a8452cf530a352c31bddfa29be41242863aa", size = 33863, upload-time = "2025-03-24T19:39:02.359Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.31.1"
 source = { registry = "https://pypi.org/simple" }
@@ -339,6 +386,7 @@ dependencies = [
     { name = "pyspark", extra = ["connect"] },
     { name = "pytest" },
     { name = "setuptools" },
+    { name = "sqlframe", extra = ["duckdb"] },
 ]
 
 [package.metadata]
@@ -346,6 +394,7 @@ requires-dist = [
     { name = "pyspark", extras = ["connect"], specifier = ">=3.5.1" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "setuptools", specifier = ">=75.8.0" },
+    { name = "sqlframe", extras = ["duckdb"], specifier = ">=3.43.8" },
 ]
 
 [package.metadata.requires-dev]
@@ -391,10 +440,58 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlframe"
+version = "3.43.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "prettytable" },
+    { name = "sqlglot" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/3d/a2280d1d22ab9ed484eaca10ff9a7c3b57f83bd6a700d6d37ea3f339188c/sqlframe-3.43.8.tar.gz", hash = "sha256:4ae44f7877dc200957ff2493a0e56392a842c435524400356aa2b7cd29c5f3ad", size = 29554720, upload-time = "2025-11-01T16:51:12.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/36/2b4d7a2ce572ccf9f698574ee581dd3534f35867dd81031282adea1bd13e/sqlframe-3.43.8-py3-none-any.whl", hash = "sha256:52e210e0352c639277f962160c1069900811522f33d8e15c2752ac5246386170", size = 210156, upload-time = "2025-11-01T16:51:10.576Z" },
+]
+
+[package.optional-dependencies]
+duckdb = [
+    { name = "duckdb" },
+    { name = "pandas" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "27.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/50/766692a83468adb1bde9e09ea524a01719912f6bc4fdb47ec18368320f6e/sqlglot-27.29.0.tar.gz", hash = "sha256:2270899694663acef94fa93497971837e6fadd712f4a98b32aee1e980bc82722", size = 5503507, upload-time = "2025-10-29T13:50:24.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/70/20c1912bc0bfebf516d59d618209443b136c58a7cff141afa7cf30969988/sqlglot-27.29.0-py3-none-any.whl", hash = "sha256:9a5ea8ac61826a7763de10cad45a35f0aa9bfcf7b96ee74afb2314de9089e1cb", size = 526060, upload-time = "2025-10-29T13:50:22.061Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -380,12 +380,11 @@ wheels = [
 
 [[package]]
 name = "pytest-pyspark-plugin"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyspark", extra = ["connect"] },
     { name = "pytest" },
-    { name = "setuptools" },
     { name = "sqlframe", extra = ["duckdb"] },
 ]
 
@@ -393,12 +392,8 @@ dependencies = [
 requires-dist = [
     { name = "pyspark", extras = ["connect"], specifier = ">=3.5.1" },
     { name = "pytest", specifier = ">=8.0.0" },
-    { name = "setuptools", specifier = ">=75.8.0" },
     { name = "sqlframe", extras = ["duckdb"], specifier = ">=3.43.8" },
 ]
-
-[package.metadata.requires-dev]
-dev = []
 
 [[package]]
 name = "python-dateutil"
@@ -419,15 +414,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "80.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**New Features :tada:**
- DuckDB as a Spark Engine if defined via `--engine`

**Maintenance**
- updated ci job versions
- upgraded pre-commit hooks
- upgraded uv 0.7 -> 0.9